### PR TITLE
AB#871 - Add initial rule files.

### DIFF
--- a/Rules/rules.task.json
+++ b/Rules/rules.task.json
@@ -1,0 +1,23 @@
+{
+  "type": "Task",
+  "rules": [
+    {
+      "ifChildState": "Active",
+      "notParentStates": [ "Active", "Resolved" ],
+      "setParentStateTo": "Active",
+      "allChildren": false
+    },
+    {
+      "ifChildState": "New",
+      "notParentStates": [ "Active", "Resolved", "New" ],
+      "setParentStateTo": "Active",
+      "allChildren": false
+    },
+    {
+      "ifChildState": "Closed",
+      "notParentStates": [],
+      "setParentStateTo": "Closed",
+      "allChildren": true
+    }
+  ]
+}

--- a/Rules/rules.user story.json
+++ b/Rules/rules.user story.json
@@ -1,0 +1,29 @@
+﻿{
+  "type": "User Story",
+  "rules": [
+    {
+      "ifChildState": "Active",
+      "notParentStates": [ "Active", "Resolved" ],
+      "setParentStateTo": "Active",
+      "allChildren": false
+    },
+    {
+      "ifChildState": "New",
+      "notParentStates": [ "Active", "Resolved", "New" ],
+      "setParentStateTo": "Active",
+      "allChildren": false
+    },
+    {
+      "ifChildState": "Resolved",
+      "notParentStates": [],
+      "setParentStateTo": "Resolved",
+      "allChildren": true
+    },
+    {
+      "ifChildState": "Closed",
+      "notParentStates": [],
+      "setParentStateTo": "Closed",
+      "allChildren": true
+    }
+  ]
+}


### PR DESCRIPTION
## What's the problem? Why do we need to change?
[AB#871](https://dev.azure.com/BoostDraft/29751c2e-aaa4-4348-8256-9e47c5acef37/_workitems/edit/871)

We need a place to store rule files for AdoAutoStateTransitions webhook, an AWS Lambda developed in https://github.com/boostdraft/azure-boards-automate-state-transitions. For this purpose we're creating a new GitHub repo that has public visibility.

At this point this is mainly testing purpose to see if the webhook Lambda can find and load the rule files. Once it's confirmed, we may add more rule files for other work item types and/or update the contents of the rule files.

## What's done in this PR?

Add two rule files as the initial set of rules to the repository. 