### PR TITLE
AB#906 - Add rules for Bug WIT.

### DIFF
--- a/Rules/rules.bug.json
+++ b/Rules/rules.bug.json
@@ -1,0 +1,23 @@
+{
+  "type": "Bug",
+  "rules": [
+    {
+      "ifChildState": "Active",
+      "notParentStates": [ "Active", "Resolved" ],
+      "setParentStateTo": "Active",
+      "allChildren": false
+    },
+    {
+      "ifChildState": "New",
+      "notParentStates": [ "Active", "Resolved", "New" ],
+      "setParentStateTo": "Active",
+      "allChildren": false
+    },
+    {
+      "ifChildState": "Closed",
+      "notParentStates": [],
+      "setParentStateTo": "Closed",
+      "allChildren": true
+    }
+  ]
+}


### PR DESCRIPTION
## What's the problem? Why do we need to change?
Fix [AB#906](https://dev.azure.com/BoostDraft/29751c2e-aaa4-4348-8256-9e47c5acef37/_workitems/edit/906).

Due to lack of rules file for Bug WIT, no action was performed triggered by update of Bug work item.

## What's done in this PR?

Add rules file for Bug WIT.