### PR TITLE
AB#936 - Bug: State transition from New to InReview does not trigger parent state change to Active

### DIFF
--- a/Rules/rules.task.json
+++ b/Rules/rules.task.json
@@ -8,6 +8,12 @@
       "allChildren": false
     },
     {
+      "ifChildState": "InReview",
+      "notParentStates": [ "Active", "Resolved" ],
+      "setParentStateTo": "Active",
+      "allChildren": false
+    },
+    {
       "ifChildState": "New",
       "notParentStates": [ "Active", "Resolved", "New" ],
       "setParentStateTo": "Active",


### PR DESCRIPTION
## What's the problem? Why do we need to change?
fix [AB#936](https://dev.azure.com/BoostDraft/29751c2e-aaa4-4348-8256-9e47c5acef37/_workitems/edit/936)

"InReview" state is not known by the rules so state transition from "New" to "InReview" did not trigger parent work item's state change.

## What's done in this PR?

Add a new rule for "InReview" state to the rules for `Task`. Now when Task's state is changed to "InReview", we'll check parent's state and update it to "Active" when necessary.